### PR TITLE
Add patient listing endpoints

### DIFF
--- a/backend/src/medecins/medecins.controller.spec.ts
+++ b/backend/src/medecins/medecins.controller.spec.ts
@@ -1,13 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MedecinsController } from './medecins.controller'
+import { MedecinsService } from './medecins.service'
 // ✅ Nom corrigé ici
 
 describe('MedecinController', () => {
   let controller: MedecinsController;
+  let service: { findPatientsByMedecin: jest.Mock };
 
   beforeEach(async () => {
+    service = { findPatientsByMedecin: jest.fn().mockResolvedValue([]) };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MedecinsController],
+      providers: [{ provide: MedecinsService, useValue: service }],
     }).compile();
 
     controller = module.get<MedecinsController>(MedecinsController);
@@ -15,5 +20,11 @@ describe('MedecinController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should return patients for the logged doctor', async () => {
+    const req = { user: { id: 1 } } as any;
+    await controller.getPatients(req);
+    expect(service.findPatientsByMedecin).toHaveBeenCalledWith(1);
   });
 });

--- a/backend/src/medecins/medecins.controller.ts
+++ b/backend/src/medecins/medecins.controller.ts
@@ -46,6 +46,20 @@ export class MedecinsController {
     return this.patientService.create(dto, req.user.id);
   }
 
+  @Get('patients')
+  async getPatients(@Request() req) {
+    return this.medecinsService.findPatientsByMedecin(req.user.id);
+  }
+
+  @Get('patients/:id')
+  async getPatient(@Param('id') id: number, @Request() req) {
+    const patient = await this.patientService.findOne(id);
+    if (!patient || patient.medecin.id !== req.user.id) {
+      throw new NotFoundException('Patient introuvable ou non autorisé');
+    }
+    return patient;
+  }
+
   @Put('patients/:id')
   async updatePatient(
     @Param('id') id: number,

--- a/backend/src/patient/patient.controller.spec.ts
+++ b/backend/src/patient/patient.controller.spec.ts
@@ -1,13 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { MedecinController } from './patient.controller';
+import { PatientController } from './patient.controller';
 import { PatientService } from '../patient/patient.service';
 
-describe('MedecinController', () => {
-  let controller: MedecinController;
+describe('PatientController', () => {
+  let controller: PatientController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      controllers: [MedecinController],
+      controllers: [PatientController],
       providers: [
         {
           provide: PatientService,
@@ -19,7 +19,7 @@ describe('MedecinController', () => {
       ],
     }).compile();
 
-    controller = module.get<MedecinController>(MedecinController);
+    controller = module.get<PatientController>(PatientController);
   });
 
   it('should be defined', () => {

--- a/backend/src/patient/patient.controller.ts
+++ b/backend/src/patient/patient.controller.ts
@@ -14,7 +14,7 @@ import { PatientService } from 'src/patient/patient.service';
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles('medecin')
 @Controller('medecin')
-export class MedecinController {
+export class PatientController {
   constructor(private readonly patientService: PatientService) {}
 
   // ✅ Supprimer un patient appartenant au médecin connecté

--- a/backend/src/patient/patient.module.ts
+++ b/backend/src/patient/patient.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { MedecinController } from './patient.controller';
+import { PatientController } from './patient.controller';
 
 import { PatientService } from './patient.service';
 import { Patient } from './patient.entity';
@@ -19,7 +19,7 @@ import { Medecin } from '../medecins/medecin.entity';
   imports: [
     TypeOrmModule.forFeature([Patient, User, RendezVous, Medecin]),
   ],
-  controllers: [MedecinController],
+  controllers: [PatientController],
 
   providers: [PatientService, UsersService, RendezvousService, PdfService, MailService],
   exports: [PatientService],

--- a/frontend/src/app/dashboard/medecin/ordonnances/page.tsx
+++ b/frontend/src/app/dashboard/medecin/ordonnances/page.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Calendar, User } from "lucide-react"
+import { toast } from "sonner"
+
+interface Patient {
+  nom: string
+  prenom: string
+}
+
+interface Ordonnance {
+  id: number
+  date: string
+  contenu: string
+  patient: Patient
+}
+
+export default function MedecinOrdonnancesPage() {
+  const [ordonnances, setOrdonnances] = useState<Ordonnance[]>([])
+
+  const fetchOrdonnances = async () => {
+    try {
+      const token = localStorage.getItem("token")
+      const res = await fetch("http://localhost:3001/medecin/ordonnances", {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error("Erreur")
+      const data = await res.json()
+      setOrdonnances(data)
+    } catch (err) {
+      console.error("Erreur chargement ordonnances", err)
+      toast.error("Impossible de charger les ordonnances")
+    }
+  }
+
+  useEffect(() => {
+    fetchOrdonnances()
+  }, [])
+
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold mb-6">Mes Ordonnances</h1>
+      {ordonnances.length === 0 ? (
+        <p className="text-gray-500">Aucune ordonnance.</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {ordonnances.map((ord) => (
+            <div key={ord.id} className="bg-white shadow-md rounded-xl p-6">
+              <div className="flex items-center gap-2 mb-2">
+                <User className="text-blue-600" />
+                <p className="font-semibold">
+                  {ord.patient.prenom} {ord.patient.nom}
+                </p>
+              </div>
+              <div className="flex items-center mb-1 text-sm text-gray-600">
+                <Calendar className="w-4 h-4 mr-2" />
+                {new Date(ord.date).toLocaleDateString()}
+              </div>
+              <p className="text-sm text-gray-600 line-clamp-2">
+                {ord.contenu}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/app/dashboard/medecin/rendezvous/page.tsx
+++ b/frontend/src/app/dashboard/medecin/rendezvous/page.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Calendar, Clock, User } from "lucide-react"
+import { toast } from "sonner"
+
+interface Patient {
+  nom: string
+  prenom: string
+}
+
+interface RendezVous {
+  id: number
+  date: string
+  heure: string
+  motif: string
+  patient: Patient
+  statut: string
+}
+
+export default function MedecinRendezVousPage() {
+  const [rendezvous, setRendezvous] = useState<RendezVous[]>([])
+
+  const fetchRdv = async () => {
+    try {
+      const token = localStorage.getItem("token")
+      const res = await fetch("http://localhost:3001/medecin/me/rendezvous", {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error("Erreur")
+      const data = await res.json()
+      setRendezvous(data)
+    } catch (err) {
+      console.error("Erreur chargement rendez-vous", err)
+      toast.error("Impossible de charger les rendez-vous")
+    }
+  }
+
+  useEffect(() => {
+    fetchRdv()
+  }, [])
+
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold mb-6">Mes Rendez-vous</h1>
+      {rendezvous.length === 0 ? (
+        <p className="text-gray-500">Aucun rendez-vous pour le moment.</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {rendezvous.map((rdv) => (
+            <div key={rdv.id} className="bg-white shadow-md rounded-xl p-6">
+              <div className="flex items-center gap-2 mb-2">
+                <User className="text-blue-600" />
+                <p className="font-semibold">
+                  {rdv.patient.prenom} {rdv.patient.nom}
+                </p>
+              </div>
+              <div className="flex items-center mb-1 text-sm text-gray-600">
+                <Calendar className="w-4 h-4 mr-2" />
+                {new Date(rdv.date).toLocaleDateString()}
+              </div>
+              <div className="flex items-center mb-1 text-sm text-gray-600">
+                <Clock className="w-4 h-4 mr-2" />
+                {rdv.heure}
+              </div>
+              <p className="text-sm text-gray-600">Motif : {rdv.motif}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add GET `/medecin/patients` and `/medecin/patients/:id`
- test controller fetch of patients

## Testing
- `npm test` in `/backend` *(fails: jest not found)*
- `npm run lint` in `/backend` *(fails: @eslint/js missing)*
- `npm run build` in `/backend` *(fails: nest not found)*
- `npm test` in `/frontend` *(fails: missing script)*
- `npm run lint` in `/frontend` *(fails: next not found)*
- `npm run build` in `/frontend` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861dcaaf9d4832282b3b1e49151fb1b